### PR TITLE
fix - when lockfile_path has more than 255 characters then reduce to 255

### DIFF
--- a/managed_nagios_plugin/resources/scripts/notify_cloudify
+++ b/managed_nagios_plugin/resources/scripts/notify_cloudify
@@ -417,6 +417,11 @@ if __name__ == '__main__':
             logger.debug('Appending service to lock path')
             lockfile_path += '_' + args.service
             logger.debug('Full lock path: {path}'.format(path=lockfile_path))
+
+        if len(lockfile_path) > 255 > len(os.path.dirname(lockfile_path)):
+            logger.debug('Path: {path} has more than 255 characters, shortening to 255'.format(path=lockfile_path))
+            lockfile_path = lockfile_path[:254]
+
         logger.debug('Attempting to acquire lock')
         try:
             acquire_lock(lockfile_path)


### PR DESCRIPTION
Plugin creates a large overhead in the name of lockfile_path.
https://github.com/cloudify-cosmo/cloudify-managed-nagios-plugin/blob/c8299530dfed64a0a32f44586814c7e545c3a130/managed_nagios_plugin/resources/scripts/notify_cloudify#L78

When lockfile_path has more than 255 characters then:
Here is the log:
[1599654016] EXTERNAL COMMAND: ADD_HOST_COMMENT;tenant:default_tenant/group_type:check_thr_sublayer;1;Cloudify;Running workflow new_cgnat_sublayer in response to health check failure for service Instance layer_group_i3_cgnat_offering_group_njkpv6_cgnat_offering_layer_uxwt2l_layer_id_bm3dxh of group check_thr_sublayer for tenant default_tenant.
[1599654016] wproc: NOTIFY job 16 from worker Core Worker 29630 is a non-check helper but exited with return code 1
[1599654016] wproc: host=tenant:default_tenant/group_type:check_thr_sublayer; service=Instance layer_group_i3_cgnat_offering_group_njkpv6_cgnat_offering_layer_uxwt2l_layer_id_bm3dxh of group check_thr_sublayer for tenant default_tenant; contact=automation
[1599654016] wproc: early_timeout=0; exited_ok=1; wait_status=256; error_code=0;
[1599654016] wproc: stderr line 01: Traceback (most recent call last):
[1599654016] wproc: stderr line 02: File "/usr/lib64/nagios/plugins/notify_cloudify", line 560, in <module>
[1599654016] wproc: stderr line 03: release_lock(lockfile_path)
[1599654016] wproc: stderr line 04: File "/usr/lib64/nagios/plugins/notify_cloudify", line 123, in release_lock
[1599654016] wproc: stderr line 05: if lockfile_belongs_to_process(lockfile_path, my_pid):
[1599654016] wproc: stderr line 06: File "/usr/lib64/nagios/plugins/notify_cloudify", line 97, in lockfile_belongs_to_process
[1599654016] wproc: stderr line 07: if pid == get_pid_from_lockfile(lockfile_path):
[1599654016] wproc: stderr line 08: File "/usr/lib64/nagios/plugins/notify_cloudify", line 104, in get_pid_from_lockfile
[1599654016] wproc: stderr line 09: with open(lockfile_path) as lockfile_handle:
[1599654016] wproc: stderr line 10: IOError: [Errno 36] File name too long: '/var/spool/nagios/cloudifyreaction/default_tenant_check_thr_sublayer_layer_group_i3_cgnat_offering_group_njkpv6_cgnat_offering_layer_uxwt2l_layer_id_bm3dxh_Instance layer_group_i3_cgnat_offering_group_njkpv6_cgnat_offering_layer_uxwt2l_layer_id_bm3dxh of group check_thr_sublayer for tenant default_tenant'

The result of the bug:
Automatic workflows related with Nagios may not work.

I added a simple check before acquiring the lock, when lockfile_path has more than 255 characters then reduce to 255. 
Please check if there will be no side effects.
 

