### PR TITLE
Fix-CircleCi-Image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ executors:
 
   wagon_generator:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202201-02
 
 
 commands:


### PR DESCRIPTION
the ubuntu image that we used to have is no longer available on circle-ci causing all jobs to fail because of that 